### PR TITLE
Show POI type in popup if it does not have its own name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog rules:
 -->
 
 ## Unreleased
+### Changed
+- Show POI type (like "Bus stop") in popup if POI does not have its proper name in source data (instead of "undefined").
 
 ## [0.4.0] - 2020-09-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ import LmcMaps from '@lmc-eu/lmc-maps';
 | center      | LngLat Array for center of map (default: `[14.4563172, 50.1028914]` or if markers are enabled value is computed automatically.).  | array
 | coords      | Array of LngLat Array for one or multiple markers on map | array
 | hasMarker   | Show markers passed in coords property (default: `false`) | boolean
-| hasInteractivePois | Make POIs like public transport stations interactive, ie. showing popup with more information on click  (default: `false`) | boolean
+| hasInteractivePois | Make POIs like public transport stations interactive, ie. showing popup with more information on click (default: `false`) | boolean
 | style       | Style id (default: `lmc-default`) ([see supported styles](https://maps.lmc.cz/#styles))  | string
-| lang        | Language of labels in map ([see supported languages](#supported-languages)) (default: native) | string
+| lang        | Language of labels in map ([see supported languages](#supported-languages)) (default: null = use native name) | string
 | authToken   | Your authorization token (must be defined for production use) | string
 | publicUrl   | Url to tileserver (default `https://tileserver.lmc.cz`) ([see more info](#tileserver)) | string
 
@@ -77,7 +77,7 @@ import LmcMaps from '@lmc-eu/lmc-maps';
 
 Currently supported languages:
 
-bg (Bulgarian), bs (Bosnian), cs (Czech), da (Danish), de (German), el (Greek), en (English), es (Spanish), et (Estonian), fi (Finnish), fr (French), hr (Croatian), hu (Hungarian), is (Icelandic), it (Italian), lt (Lithuanian), lv (Latvian), mk (Macedonian), nl (Dutch), pl (Polish), pt (Portuguese), ro (Romania), ru (Russian), sk (Slovak), sl (Slovene), sq (Albanian), sr (Serbian), sv (Swedish), tr (Turkish), uk (Ukrainian)
+cs (Czech), de (German), en (English), fi (Finnish), pl (Polish), sk (Slovak)
 
 #### Tileserver `publicUrl` and `authToken` <a name="tileserver"></a>
 
@@ -101,13 +101,13 @@ For latest changes see [CHANGELOG.md](CHANGELOG.md) file. We follow [Semantic Ve
 ### Install dependencies
 
 ```bash
-npm install
+yarn
 ```
 
 ### Start local Webpack dev server
 
 ```bash
-npm start
+yarn start
 ```
 
 run on `localhost:3001`
@@ -117,5 +117,5 @@ run on `localhost:3001`
 Build lib bundle to `dist` folder.
 
 ```bash
-npm run build
+yarn build
 ```

--- a/src/lib/lmc-maps.ts
+++ b/src/lib/lmc-maps.ts
@@ -117,7 +117,7 @@ class LmcMaps {
 
             const features = this.getPointFeatures(point, layers);
             features.forEach((feature) => {
-                createPopup(feature)?.addTo(this.map);
+                createPopup(feature, this.lang)?.addTo(this.map);
             });
         });
     }

--- a/src/lib/utils/popups.ts
+++ b/src/lib/utils/popups.ts
@@ -1,11 +1,22 @@
 import mapboxgl from 'mapbox-gl';
+import { getTranslation } from './translations';
+import { Languages } from '../types';
 
-export const createPopup = (feature: mapboxgl.MapboxGeoJSONFeature): mapboxgl.Popup => {
+export const createPopup = (
+    feature: mapboxgl.MapboxGeoJSONFeature,
+    lang: Languages
+): mapboxgl.Popup => {
     if (feature.geometry.type !== 'Point') {
         return null;
     }
 
     const [lon, lat] = feature.geometry.coordinates;
+
+    let stationName = feature.properties.name;
+
+    if (stationName === undefined) {
+        stationName = getTranslation(lang, feature.layer.id);
+    }
 
     const popup = new mapboxgl.Popup({
         offset: [0, -12],
@@ -13,7 +24,7 @@ export const createPopup = (feature: mapboxgl.MapboxGeoJSONFeature): mapboxgl.Po
         className: 'lmc-maps__popup'
     })
         .setLngLat({ lon, lat })
-        .setHTML(`<div>${feature.properties.name}</div>`);
+        .setHTML(`<div>${stationName}</div>`);
 
     return popup;
 };

--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -1,0 +1,60 @@
+import { Languages } from '../types';
+
+type TranslationSet = {
+    cs: string;
+    de: string;
+    en: string;
+    fi: string;
+    pl: string;
+    sk: string;
+};
+
+type Translations = Record<string, TranslationSet>;
+
+const TRANSLATIONS: Translations = {
+    'label_poi-bus': {
+        cs: 'Zastávka autobusu',
+        de: 'Bushaltestelle',
+        en: 'Bus stop',
+        fi: 'Bussipysäkki',
+        pl: 'Przystanek autobusowy',
+        sk: 'Zastávka autobusu'
+    },
+    'label_poi-subway': {
+        cs: 'Stanice metra',
+        de: 'U-Bahnstation',
+        en: 'Subway station',
+        fi: 'Metroasema',
+        pl: 'Stacja metra',
+        sk: 'Stanica metra'
+    },
+    'label_poi-tram-stop': {
+        cs: 'Zastávka tramvaje',
+        de: 'Straßenbahnhaltestelle',
+        en: 'Tram stop',
+        fi: 'Raitiovaunupysäkki',
+        pl: 'Przystanek tramwajowy',
+        sk: 'Zastávka električky'
+    },
+    'label_poi-railway-station': {
+        cs: 'Vlaková zastávka',
+        de: 'Bahnhof',
+        en: 'Train station',
+        fi: 'Juna-asema',
+        pl: 'Przystanek kolejowy',
+        sk: 'Vlaková zastávka'
+    }
+};
+
+export const getTranslation = (lang: Languages, message: string): string => {
+    if (!(message in TRANSLATIONS)) {
+        return message;
+    }
+
+    let langForTranslation = lang;
+    if (lang === null) {
+        langForTranslation = 'cs';
+    }
+
+    return TRANSLATIONS[message][langForTranslation];
+};

--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -51,10 +51,7 @@ export const getTranslation = (lang: Languages, message: string): string => {
         return message;
     }
 
-    let langForTranslation = lang;
-    if (lang === null) {
-        langForTranslation = 'cs';
-    }
+    const langForTranslation = lang || 'cs';
 
     return TRANSLATIONS[message][langForTranslation];
 };


### PR DESCRIPTION
If eg. bus stop does not have its proper name in source OSM data, we will show in popup its generic type (like "Bus stop") instead of "undefined".

To accomplish this, we need to provide POI type translation for supported languages.

Also note this is just a naive and simple translation system, if it will be ever expanded, we may switch to some proper i18n library.