### PR TITLE
Fix Webpack CLI and the `start` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "start": "webpack-dev-server --config webpack.config.js",
+    "start": "webpack serve --config webpack.config.js",
     "build": "rimraf dist/* && yarn run tslint && rollup -c",
     "tslint": "eslint . --ext .ts"
   },


### PR DESCRIPTION
  * `webpack-dev-server` was replaced with `webpack serve` in v5